### PR TITLE
Form improvement

### DIFF
--- a/src/components/canvas/Configurations.tsx
+++ b/src/components/canvas/Configurations.tsx
@@ -2,6 +2,9 @@ import React from "react";
 import {useGlobalState} from "../../state/appState";
 import SingleConfig from "../configuration/SingleConfig";
 import {Repository} from "../../model/Repository";
+import Typography from '@material-ui/core/Typography';
+import {Card} from '@material-ui/core';
+import { CardContent } from '@material-ui/core';
 
 /**
  *
@@ -14,13 +17,23 @@ const Configurations = () => {
 
     return (
         <React.Fragment>
-            request
-            {request.systemName}
-            {request.repositories.map((m: Repository) => (
-                <>
-                    <SingleConfig conf={m}/>
-                </>
-            ))}
+            <Card style={{marginBottom: '20px'}}>
+                <CardContent >
+                    <Typography component="h4" variant="h4">
+                        Repository
+                    </Typography>
+                    {request.repositories.map((m: Repository) => (
+                        <>
+                            <SingleConfig conf={m}/>
+                        </>
+                    ))}
+                    {request.systemName && request.systemName.length > 0 &&
+                        <Typography component="h5" variant="h5" style={{marginTop:'15px'}}>
+                            Project: {request.systemName}
+                        </Typography>
+                    }
+                </CardContent>
+            </Card>
         </React.Fragment>
     )
 }

--- a/src/components/configuration/ConfigForm.tsx
+++ b/src/components/configuration/ConfigForm.tsx
@@ -60,8 +60,6 @@ const ConfigForm = (conf: ConfigProps) => {
                     helperText={isError() && <p>Failed to clone this repository!</p>}
                 />
 
-                {/* {isError() && <p>Error Message</p>} */}
-
                 <Button variant="contained" color="primary" type="submit">
                     Submit
                 </Button>

--- a/src/components/configuration/ConfigForm.tsx
+++ b/src/components/configuration/ConfigForm.tsx
@@ -26,6 +26,14 @@ const ConfigForm = (conf: ConfigProps) => {
         ActionsRegister.setGithubUrl(url);
     }
 
+    /**
+     * Stub function, should be replaced somewhere by an error check
+     * @param u
+     */
+    const isError = (): boolean => {
+        return false;
+    }
+
     const handleSubmit = async (e) => {
         e.preventDefault();
         console.log(url);
@@ -37,9 +45,11 @@ const ConfigForm = (conf: ConfigProps) => {
             <form noValidate autoComplete="off" onSubmit={handleSubmit}>
                 <TextField
                     id="github-url"
+                    error={isError()}
+                    label="Repository URL (GitHub /organization/repository)"
                     type="text"
                     style={{ margin: 8 }}
-                    placeholder="Github URL here"
+                    placeholder="GitHub URL here"
                     fullWidth
                     margin="normal"
                     InputLabelProps={{
@@ -47,9 +57,10 @@ const ConfigForm = (conf: ConfigProps) => {
                     }}
                     value={url}
                     onChange={handleChange}
+                    helperText={isError() && <p>Failed to clone this repository!</p>}
                 />
 
-                <p>Error Message</p>
+                {/* {isError() && <p>Error Message</p>} */}
 
                 <Button variant="contained" color="primary" type="submit">
                     Submit


### PR DESCRIPTION
Closes #61

Put form inside a card, added labels, added states for displaying error message. Actual error check is currently a stub, just replace it with something that actually checks for repo error (if you point me to where you check for errors, I could probably wire it up):
```
<TextField
    id="github-url"
    error={someErrorCheck()}
    ...
    helperText={someErrorCheck() && <p>Failed to clone this repository!</p>}
/>
```
Non-error state:
<img width="599" alt="Screen Shot 2020-05-21 at 10 28 15 PM" src="https://user-images.githubusercontent.com/57876607/82628710-2f1b7000-9bb3-11ea-86ae-b297f639feaa.png">

Error state:
<img width="499" alt="Screen Shot 2020-05-21 at 10 27 37 PM" src="https://user-images.githubusercontent.com/57876607/82628925-d698a280-9bb3-11ea-91cf-4f44d7ec3e5e.png">
